### PR TITLE
Remove docstring from proc_fs.py

### DIFF
--- a/kernel_ai/collectors/proc_fs.py
+++ b/kernel_ai/collectors/proc_fs.py
@@ -1,10 +1,3 @@
-"""
-Filesystem collectors for kernel introspection.
-
-Tests should patch functions in ``kernel_ai.collectors.proc_fs`` (or this module's
-attributes) rather than the whole webapp.
-"""
-
 from __future__ import annotations
 
 


### PR DESCRIPTION
Removed docstring explaining filesystem collectors for kernel introspection.