### PR TITLE
Delete unnecessary docstring from kernel_maps.py

### DIFF
--- a/kernel_ai/services/kernel_maps.py
+++ b/kernel_ai/services/kernel_maps.py
@@ -1,5 +1,3 @@
-"""Kernel syscall maps and subsystem mapping helpers."""
-
 from __future__ import annotations
 
 


### PR DESCRIPTION
Removed docstring for kernel syscall maps.